### PR TITLE
Simplify and document parameter passing

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths   ["src" "assets" "profiles"]
  :deps    {org.clojure/tools.cli          {:mvn/version "1.0.219"}
-           ring/ring-core                 {:mvn/version "1.10.0"}
+           ring/ring-codec                {:mvn/version "1.2.0"}
            org.babashka/http-client       {:mvn/version "0.4.15"}
            org.clojure/data.json          {:mvn/version "2.4.0"}
            hiccup/hiccup                  {:mvn/version "2.0.0-RC2"}

--- a/docs/specification-authors.md
+++ b/docs/specification-authors.md
@@ -80,7 +80,8 @@ use the placeholders:
              [:response :body "pageNumber" ?pageNumber]
              [:response :body "hasNextPage" true]]
  :generates [{:method "get"
-              :path   "{?path}?pageNumber={(inc ?pageNumber)}"}]}
+              :path   ?path
+              :query-params {"pageNumber" "{(inc ?pageNumber)}"}}]}
 ```
 
 Literal entries are integers, keywords (starting with `:`) and quoted
@@ -115,7 +116,9 @@ value.  This can be used to match multiple entries in a list:
              [:response :body "customers" ?index "name" ?name]]
 
  :generates [{:method "get"
-              :path   "/customer?id={?id}&name={?name}"}]}
+              :path   "/customer"
+              :query-params {"id" ?id
+                             "name" ?name}}]}
 ```
 
 If the interaction response body contains a `"customers"` list of maps
@@ -134,9 +137,37 @@ A generator template looks like a RING request map:
  :headers {"X-Header" "Header-value"}}
 ```
 
-You can insert expressions in the template by using `{...}`
-brackets. Placeholders are available in expressions.  S-expressions
-can be used for function calls.
+Possible keys
+
+ - :body -- request body string or vector / map to be passed as json
+ - :form-params -- a map of request body parameters (will be form encoded)
+ - :host -- address of remote host
+ - :method -- request method, "get", "post" etc
+ - :path -- the URI path, /without/ query string or host
+ - :port -- network port, optional
+ - :query-params -- map of query parameters
+ - :scheme -- scheme; "http" or "https"
+ 
+
+These will be merged with the provided values from `base-uri` when
+spidering, so usually `:host` `:scheme` and `:port` should be left
+off.
+
+Query parameters can be provided using `:query-params`, a map of
+key-value pairs, with vectors for params that appear multiple times:
+
+```clojure
+{:method "get"
+ :path   "/some/character"
+ :query-params {"medium" "TV"
+                "format" "cartoon"
+                "extra" ?extraPlaceholder}}
+```
+
+You can insert expressions in the template by using `{...}`  brackets
+in strings, or directly in vector elements and map values (not in map
+keys). Placeholders are expressions in templates.  S-expressions can
+be used for function calls.
 
 The following functions are available in expressions:
 

--- a/profiles/ooapi
+++ b/profiles/ooapi
@@ -28,14 +28,15 @@
 
  :rules
  [;; page through items list for any kind of entity
-  {:match     [[:request, :method, "get"]
-               [:request, :path, ?path]
+  {:match     [[:request :method, "get"]
+               [:request :path ?path]
                [:response :status 200]
                [:response, :body, "pageNumber", ?pageNumber]
                [:response, :body, "hasNextPage", true]]
-   :generates [{:method "get"
-                :path   "{?path}?pageNumber={(inc ?pageNumber)}"}]}
-
+   :generates [{:method       "get"
+                :path         ?path
+                ;; params must be passed as strings
+                :query-params {"pageNumber" "{(inc ?pageNumber)}"}}]}
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "academicSessionId" ?id]]

--- a/profiles/rio
+++ b/profiles/rio
@@ -1,45 +1,57 @@
 {:openapi-spec "rio.openapi.json"
  :seeds
- [{:method "get"
-   :path   "/courses"}
-  {:method "get"
-   :path   "/education-specifications"}
-  {:method "get"
-   :path   "/programs"}]
+ [{:method       "get"
+   :path         "/courses"
+   :query-params {"consumer" "rio"}}
+  {:method       "get"
+   :path         "/education-specifications"
+   :query-params {"consumer" "rio"}}
+  {:method       "get"
+   :path         "/programs"
+   :query-params {"consumer" "rio"}}]
 
  :rules
- [;; page through items list for any kind of entity
-  {:match     [[:request, :method, "get"]
-               [:request, :path, ?path]
+ [;; page through items list for any kind of entity, assumes consumer query param is present
+  {:match     [[:request :method, "get"]
+               [:request :path ?path]
+               [:request :query-params "consumer" ?consumer]
                [:response :status 200]
                [:response, :body, "pageNumber", ?pageNumber]
                [:response, :body, "hasNextPage", true]]
-   :generates [{:method "get"
-                :path   "{?path}?pageNumber={(inc ?pageNumber)}"}]}
-
+   :generates [{:method       "get"
+                :path         ?path
+                :query-params {"pageNumber" "{(inc ?pageNumber)}" ;; params must be strings
+                               "consumer"   ?consumer}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "courseId" ?id]]
-   :generates [{:method "get"
-                :path   "/courses/{?id}"}
-               {:method "get"
-                :path   "/courses/{?id}/offerings"}]}
+   :generates [{:method       "get"
+                :path         "/courses/{?id}"
+                :query-params {"consumer" "rio"}}
+               {:method       "get"
+                :path         "/courses/{?id}/offerings"
+                :query-params {"consumer" "rio"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "educationSpecificationId" ?id]]
-   :generates [{:method "get"
-                :path   "/education-specifications/{?id}"}]}
+   :generates [{:method       "get"
+                :path         "/education-specifications/{?id}"
+                :query-params {"consumer" "rio"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "programId" ?id]]
-   :generates [{:method "get"
-                :path   "/programs/{?id}"}
-               {:method "get"
-                :path   "/programs/{?id}/programs"}
-               {:method "get"
-                :path   "/programs/{?id}/courses"}
-               {:method "get"
-                :path   "/programs/{?id}/offerings"}]}]}
+   :generates [{:method       "get"
+                :path         "/programs/{?id}"
+                :query-params {"consumer" "rio"}}
+               {:method       "get"
+                :path         "/programs/{?id}/programs"
+                :query-params {"consumer" "rio"}}
+               {:method       "get"
+                :path         "/programs/{?id}/courses"
+                :query-params {"consumer" "rio"}}
+               {:method       "get"
+                :path         "/programs/{?id}/offerings"
+                :query-params {"consumer" "rio"}}]}]}


### PR DESCRIPTION
We previously implied that :path values in request templates could contain parameters but that was broken and complicates parameter passing.

This change documents the format of request templates and specifies that parameters are passed :query-params maps.