### PR TITLE
Quickfix: spec/profile typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ OPTIONS:
   -u, --base-url BASE-URL                                 Base URL of service to validate.
   -o, --observations OBSERVATIONS-PATH  observations.edn  Path to read/write spidering observations.
   -p, --report REPORT-PATH              report.html       Path to write report.
-  -r, --profile PROFILE                 ooapi             Path to profile or name of builtin profile
+  -r, --profile PROFILE                 ooapi             Path to profile
   -S, --no-spider                       false             Disable spidering (re-use observations from OBSERVATIONS-PATH).
   -P, --no-report                       false             Disable report generation (spidering will write observations).
   -h, --add-header 'HEADER: VALUE'      {}                Add header to request. Can be used multiple times.

--- a/README.md
+++ b/README.md
@@ -110,9 +110,11 @@ A few SURFeduhub profiles are available in the [profiles](./profiles)
 directory and are built into the binary releases:
 
   - `ooapi` -- the full OOAPI v5 specification
+  - `ooapi-v6` -- the full OOAPI v6 specification
   - `rio` -- the RIO profile of OOAPI v5.
+  - `rio-v6` -- the RIO profile of OOAPI v6
   - `eduxchange` -- the eduxchange profile of OOAPI v5.
-
+  
 # Extending the validator
 
 ## Common validator source

--- a/README.src.md
+++ b/README.src.md
@@ -80,9 +80,11 @@ A few SURFeduhub profiles are available in the [profiles](./profiles)
 directory and are built into the binary releases:
 
   - `ooapi` -- the full OOAPI v5 specification
+  - `ooapi-v6` -- the full OOAPI v6 specification
   - `rio` -- the RIO profile of OOAPI v5.
+  - `rio-v6` -- the RIO profile of OOAPI v6
   - `eduxchange` -- the eduxchange profile of OOAPI v5.
-
+  
 # Extending the validator
 
 ## Common validator source

--- a/deps.edn
+++ b/deps.edn
@@ -4,8 +4,8 @@
 
 {:paths   ["generated/resources" "profiles" "src"]
  :deps    {nl.surf/apie {:git/url "https://github.com/SURFnet/apie.git"
-                         :git/tag "v1.0.3"
-                         :git/sha "d7d8b74b764b00556222be274266ce19db585528"}}
+                         :git/tag "v1.0.4"
+                         :git/sha "269bd5a03f12ba7867bac4c61152d2ceb1aadcd8"}}
  :aliases {:test      {:extra-deps {lambdaisland/kaocha {:mvn/version "RELEASE"}}
                        :main-opts  ["-m" "kaocha.runner"]}
            :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}

--- a/deps.edn
+++ b/deps.edn
@@ -4,8 +4,8 @@
 
 {:paths   ["generated/resources" "profiles" "src"]
  :deps    {nl.surf/apie {:git/url "https://github.com/SURFnet/apie.git"
-                         :git/tag "v1.0.2"
-                         :git/sha "053486c1c7175bbf966fe4729f3abd07574d138b"}}
+                         :git/tag "v1.0.3"
+                         :git/sha "d7d8b74b764b00556222be274266ce19db585528"}}
  :aliases {:test      {:extra-deps {lambdaisland/kaocha {:mvn/version "RELEASE"}}
                        :main-opts  ["-m" "kaocha.runner"]}
            :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}

--- a/profiles/eduxchange
+++ b/profiles/eduxchange
@@ -2,17 +2,20 @@
  :seeds
  [{:method "get"
    :path   "/courses"
-   :query-params {"consumer" "eduxchange"}
+   :query-params {"consumer" "eduxchange"
                   "pageSize" "250"}
+   :headers {"accept" "application/json"}}
   {:method "get"
    :path   "/organizations"
-   :query-params {"consumer" "eduxchange"}
+   :query-params {"consumer" "eduxchange"
                   "organizationType" "root"}
+   :headers {"accept" "application/json"}}
   {:method "get"
    :path   "/programs"
-   :query-params {"consumer" "eduxchange"}
+   :query-params {"consumer" "eduxchange"
                   "programType" "minor"
-                  "pageSize" "250"}]
+                  "pageSize" "250"}
+   :headers {"accept" "application/json"}}]
 
  :rules
  [;; page through items list for any kind of entity
@@ -25,7 +28,8 @@
    :generates [{:method       "get"
                 :path         ?path
                 ;; params must be passed as strings
-                :query-params (assoc ?query-params "pageNumber" (str (inc ?pageNumber)))}]}
+                :query-params (assoc ?query-params "pageNumber" (str (inc ?pageNumber)))
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
@@ -33,10 +37,12 @@
    :generates [{:method "get"
                 :path   "/courses/{?id}"
                 :query-params {"consumer" "eduxchange"
-                               "expand" "coordinators"}}
+                               "expand" "coordinators"}
+                :headers {"accept" "application/json"}}
                {:method "get"
                 :path   "/courses/{?id}/offerings"
-                :query-params {"consumer" "eduxchange"}}]}
+                :query-params {"consumer" "eduxchange"}
+                :headers {"accept" "application/json"}}]}
 
   ;; from any kind of offering
   {:match     [[:request, :method, "get"]
@@ -45,7 +51,8 @@
    :generates [{:method "get"
                 :path   "/offerings/{?id}"
                 :query-params {"consumer" "eduxchange"
-                               "expand" "academicSession"}}]}
+                               "expand" "academicSession"}
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
@@ -53,7 +60,9 @@
    :generates [{:method "get"
                 :path   "/programs/{?id}"
                 :query-params {"consumer" "eduxchange"
-                               "expand" "coordinators,organization"}}
+                               "expand" "coordinators,organization"}
+                :headers {"accept" "application/json"}}
                {:method "get"
                 :path   "/programs/{?id}/offerings"
-                :query-params {"consumer" "eduxchange"}}]}]}
+                :query-params {"consumer" "eduxchange"}
+                :headers {"accept" "application/json"}}]}]}

--- a/profiles/ooapi
+++ b/profiles/ooapi
@@ -1,30 +1,41 @@
 {:openapi-spec "ooapi.openapi.json"
  :seeds
  [{:method "get"
-   :path   "/"}
+   :path   "/"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/academic-sessions"}
+   :path   "/academic-sessions"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/buildings"}
-
+   :path   "/buildings"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/courses"}
+   :path   "/courses"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/education-specifications"}
+   :path   "/education-specifications"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/groups"}
+   :path   "/groups"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/news-feeds"}
+   :path   "/news-feeds"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/organizations"}
+   :path   "/organizations"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/persons"}
+   :path   "/persons"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/persons/me"}
+   :path   "/persons/me"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/programs"}
+   :path   "/programs"
+   :headers {"accept" "application/json"}}
   {:method "get"
-   :path   "/rooms"}]
+   :path   "/rooms"
+   :headers {"accept" "application/json"}}]
 
  :rules
  [;; page through items list for any kind of entity
@@ -36,133 +47,171 @@
                [:response, :body, "hasNextPage", true]]
    :generates [{:method       "get"
                 :path         ?path
+                :headers {"accept" "application/json"}
                 ;; params must be passed as strings
                 :query-params (assoc ?query-params "pageNumber" (str (inc ?pageNumber)))}]}
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "academicSessionId" ?id]]
    :generates [{:method "get"
-                :path   "/academic-sessions/{?id}"}
+                :path   "/academic-sessions/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/academic-sessions/{?id}/offerings"}]}
+                :path   "/academic-sessions/{?id}/offerings"
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "buildingId" ?id]]
    :generates [{:method "get"
-                :path   "/buildings/{?id}"}
+                :path   "/buildings/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/buildings/{?id}/rooms"}]}
+                :path   "/buildings/{?id}/rooms"
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "courseId" ?id]]
    :generates [{:method "get"
-                :path   "/courses/{?id}"}
+                :path   "/courses/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/courses/{?id}/components"}
+                :path   "/courses/{?id}/components"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/courses/{?id}/offerings"}]}
+                :path   "/courses/{?id}/offerings"
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "educationSpecificationId" ?id]]
    :generates [{:method "get"
-                :path   "/education-specifications/{?id}"}
+                :path   "/education-specifications/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/education-specifications/{?id}/courses"}
+                :path   "/education-specifications/{?id}/courses"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/education-specifications/{?id}/education-specifications"}
+                :path   "/education-specifications/{?id}/education-specifications"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/education-specifications/{?id}/programs"}]}
+                :path   "/education-specifications/{?id}/programs"
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "groupId" ?id]]
    :generates [{:method "get"
-                :path   "/groups/{?id}"}
+                :path   "/groups/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/groups/{?id}/persons"}]}
+                :path   "/groups/{?id}/persons"
+                :headers {"accept" "application/json"}}]}
 
   ;; from any kind of offering
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "offeringId" ?id]]
    :generates [{:method "get"
-                :path   "/offerings/{?id}"}
+                :path   "/offerings/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/offerings/{?id}/associations"}
+                :path   "/offerings/{?id}/associations"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/offerings/{?id}/groups"}]}
+                :path   "/offerings/{?id}/groups"
+                :headers {"accept" "application/json"}}]}
 
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "organizationId" ?id]]
    :generates [{:method "get"
-                :path   "/organizations/{?id}"}
+                :path   "/organizations/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/organizations/{?id}/programs"}
+                :path   "/organizations/{?id}/programs"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/organizations/{?id}/courses"}
+                :path   "/organizations/{?id}/courses"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/organizations/{?id}/components"}
+                :path   "/organizations/{?id}/components"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/organizations/{?id}/offerings"}
+                :path   "/organizations/{?id}/offerings"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/organizations/{?id}/groups"}
+                :path   "/organizations/{?id}/groups"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/organizations/{?id}/education-specifications"}]}
+                :path   "/organizations/{?id}/education-specifications"
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "personId" ?id]]
    :generates [{:method "get"
-                :path   "/persons/{?id}"}
+                :path   "/persons/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/persons/{?id}/associations"}
+                :path   "/persons/{?id}/associations"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/persons/{?id}/groups"}]}
+                :path   "/persons/{?id}/groups"
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:path "/persons/me"]
                [:response, :body, "personId" ?id]]
    :generates [{:method "get"
-                :path   "/persons/{?id}"}
+                :path   "/persons/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/persons/{?id}/associations"}
+                :path   "/persons/{?id}/associations"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/persons/{?id}/groups"}]}
+                :path   "/persons/{?id}/groups"
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "programId" ?id]]
    :generates [{:method "get"
-                :path   "/programs/{?id}"}
+                :path   "/programs/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/programs/{?id}/programs"}
+                :path   "/programs/{?id}/programs"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/programs/{?id}/courses"}
+                :path   "/programs/{?id}/courses"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/programs/{?id}/offerings"}]}
+                :path   "/programs/{?id}/offerings"
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "roomId" ?id]]
    :generates [{:method "get"
-                :path   "/rooms/{?id}"}]}
+                :path   "/rooms/{?id}"
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "newsFeedId" ?id]]
    :generates [{:method "get"
-                :path   "/news-feeds/{?id}"}
+                :path   "/news-feeds/{?id}"
+                :headers {"accept" "application/json"}}
                {:method "get"
-                :path   "/news-feeds/{?id}/news-items"}]}
+                :path   "/news-feeds/{?id}/news-items"
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "newsItemId" ?id]]
    :generates [{:method "get"
-                :path   "/news-items/{?id}"}]}]}
+                :path   "/news-items/{?id}"
+                :headers {"accept" "application/json"}}]}]}

--- a/profiles/ooapi-v6
+++ b/profiles/ooapi-v6
@@ -1,28 +1,39 @@
 {:openapi-spec "ooapi-v6.openapi.json"
  :seeds
  [{:method "get"
-   :path   "/"}
+   :path   "/"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
   {:method "get"
-   :path   "/academic-sessions"}
+   :path   "/academic-sessions"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
   {:method "get"
-   :path   "/buildings"}
+   :path   "/buildings"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
 
   {:method "get"
-   :path   "/courses"}
+   :path   "/courses"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
   {:method "get"
-   :path   "/groups"}
+   :path   "/groups"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
   {:method "get"
-   :path   "/organisations"}
+   :path   "/organisations"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
   {:method "get"
-   :path   "/persons"}
+   :path   "/persons"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
   {:method "get"
-   :path   "/persons/me"}
+   :path   "/persons/me"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
   {:method "get"
-   :path   "/programmes"}
+   :path   "/programmes"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
   {:method "get"
-   :path   "/rooms"}
+   :path   "/rooms"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
   {:method "get"
-   :path   "/learning-outcomes"}]
+   :path   "/learning-outcomes"
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}]
 
  :rules
  [;; page through items list for any kind of entity
@@ -35,40 +46,52 @@
    :generates [{:method       "get"
                 :path         ?path
                 ;; params must be passed as strings
-                :query-params (assoc ?query-params "pageNumber" (str (inc ?pageNumber)))}]}
+                :query-params (assoc ?query-params "pageNumber" (str (inc ?pageNumber)))
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "academicSessionId" ?id]]
    :generates [{:method "get"
-                :path   "/academic-sessions/{?id}"}
+                :path   "/academic-sessions/{?id}"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/academic-sessions/{?id}/course-offerings"}
+                :path   "/academic-sessions/{?id}/course-offerings"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/academic-sessions/{?id}/programme-offerings"}
+                :path   "/academic-sessions/{?id}/programme-offerings"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/academic-sessions/{?id}/learning-component-offerings"}
+                :path   "/academic-sessions/{?id}/learning-component-offerings"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/academic-sessions/{?id}/test-component-offerings"}]}
+                :path   "/academic-sessions/{?id}/test-component-offerings"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "buildingId" ?id]]
    :generates [{:method "get"
-                :path   "/buildings/{?id}"}
+                :path   "/buildings/{?id}"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/buildings/{?id}/rooms"}]}
+                :path   "/buildings/{?id}/rooms"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "courseId" ?id]]
    :generates [{:method "get"
-                :path   "/courses/{?id}"}
+                :path   "/courses/{?id}"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/courses/{?id}/learning-components"}
+                :path   "/courses/{?id}/learning-components"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/courses/{?id}/test-components"}
+                :path   "/courses/{?id}/test-components"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/courses/{?id}/course-offerings"}]}
+                :path   "/courses/{?id}/course-offerings"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
@@ -76,17 +99,21 @@
    :generates [{:method "get"
                 :path   "/groups/{?id}"}
                {:method "get"
-                :path   "/groups/{?id}/memberships"}]}
+                :path   "/groups/{?id}/memberships"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "courseOfferingId" ?id]]
    :generates [{:method "get"
-                :path   "/course-offerings/{?id}"}
+                :path   "/course-offerings/{?id}"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/course-offerings/{?id}/course-offering-associations"}
+                :path   "/course-offerings/{?id}/course-offering-associations"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/course-offerings/{?id}/groups"}]}
+                :path   "/course-offerings/{?id}/groups"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
   
   {:match     [[:request, :method, "get"]
                [:response :status 200]
@@ -94,85 +121,113 @@
    :generates [{:method "get"
                 :path   "/programme-offerings/{?id}"}
                {:method "get"
-                :path   "/programme-offerings/{?id}/programme-offering-associations"}
+                :path   "/programme-offerings/{?id}/programme-offering-associations"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/programme-offerings/{?id}/groups"}]}
+                :path   "/programme-offerings/{?id}/groups"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "organisationId" ?id]]
    :generates [{:method "get"
-                :path   "/organisations/{?id}"}
+                :path   "/organisations/{?id}"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/organisations/{?id}/programmes"}
+                :path   "/organisations/{?id}/programmes"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/organisations/{?id}/courses"}
+                :path   "/organisations/{?id}/courses"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/organisations/{?id}/learning-components"}
+                :path   "/organisations/{?id}/learning-components"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/organisations/{?id}/learning-component-offerings"}
+                :path   "/organisations/{?id}/learning-component-offerings"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/organisations/{?id}/test-components"}
+                :path   "/organisations/{?id}/test-components"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/organisations/{?id}/test-component-offerings"}
+                :path   "/organisations/{?id}/test-component-offerings"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/organisations/{?id}/course-offerings"}
+                :path   "/organisations/{?id}/course-offerings"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/organisations/{?id}/programme-offerings"}
+                :path   "/organisations/{?id}/programme-offerings"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/organisations/{?id}/groups"}]}
+                :path   "/organisations/{?id}/groups"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "personId" ?id]]
    :generates [{:method "get"
-                :path   "/persons/{?id}"}
+                :path   "/persons/{?id}"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/persons/{?id}/course-offering-associations"} 
+                :path   "/persons/{?id}/course-offering-associations"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/persons/{?id}/programme-offering-associations"}
+                :path   "/persons/{?id}/programme-offering-associations"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/persons/{?id}/learning-component-offering-associations"}
+                :path   "/persons/{?id}/learning-component-offering-associations"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/persons/{?id}/test-component-offering-associations"}]}
+                :path   "/persons/{?id}/test-component-offering-associations"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:path "/persons/me"]
                [:response, :body, "personId" ?id]]
    :generates [{:method "get"
-                :path   "/persons/{?id}"}
+                :path   "/persons/{?id}"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/persons/{?id}/course-offering-associations"}
+                :path   "/persons/{?id}/course-offering-associations"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/persons/{?id}/programme-offering-associations"}
+                :path   "/persons/{?id}/programme-offering-associations"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/persons/{?id}/learning-component-offering-associations"}
+                :path   "/persons/{?id}/learning-component-offering-associations"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/persons/{?id}/test-component-offering-associations"}]}
+                :path   "/persons/{?id}/test-component-offering-associations"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "programmeId" ?id]]
    :generates [{:method "get"
-                :path   "/programmes/{?id}"}
+                :path   "/programmes/{?id}"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/programmes/{?id}/programmes"}
+                :path   "/programmes/{?id}/programmes"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/programmes/{?id}/courses"}
+                :path   "/programmes/{?id}/courses"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}
                {:method "get"
-                :path   "/programmes/{?id}/programme-offerings"}]}
+                :path   "/programmes/{?id}/programme-offerings"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "roomId" ?id]]
    :generates [{:method "get"
-                :path   "/rooms/{?id}"}]}
+                :path   "/rooms/{?id}"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "learningOutcomeId" ?id]]
    :generates [{:method "get"
-                :path   "/learning-outcomes/{?id}"}]}
+                :path   "/learning-outcomes/{?id}"
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 ]}

--- a/profiles/ooapi-v6
+++ b/profiles/ooapi-v6
@@ -111,11 +111,11 @@
                {:method "get"
                 :path   "/organisations/{?id}/learning-components"}
                {:method "get"
-                :path   "/organisations/{?id}/learning-components-offerings"}
+                :path   "/organisations/{?id}/learning-component-offerings"}
                {:method "get"
                 :path   "/organisations/{?id}/test-components"}
                {:method "get"
-                :path   "/organisations/{?id}/test-components-offerings"}
+                :path   "/organisations/{?id}/test-component-offerings"}
                {:method "get"
                 :path   "/organisations/{?id}/course-offerings"}
                {:method "get"

--- a/profiles/ooapi-v6.openapi.json
+++ b/profiles/ooapi-v6.openapi.json
@@ -595,7 +595,10 @@
                       ],
                       "properties": {
                         "items": {
-                          "$ref": "#/components/schemas/CourseOffering"
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CourseOffering"
+                          }
                         },
                         "ext": {
                           "$ref": "#/components/schemas/Ext"

--- a/profiles/rio
+++ b/profiles/rio
@@ -2,13 +2,16 @@
  :seeds
  [{:method "get"
    :path   "/courses"
-   :query-params {"consumer" "rio"}}
+   :query-params {"consumer" "rio"}
+   :headers {"accept" "application/json"}}
   {:method "get"
    :path   "/education-specifications"
-   :query-params {"consumer" "rio"}}
+   :query-params {"consumer" "rio"}
+   :headers {"accept" "application/json"}}
   {:method "get"
    :path   "/programs"
-   :query-params {"consumer" "rio"}}]
+   :query-params {"consumer" "rio"}
+   :headers {"accept" "application/json"}}]
 
  :rules
  [;; page through items list for any kind of entity
@@ -20,7 +23,8 @@
                [:response, :body, "hasNextPage", true]]
    :generates [{:method "get"
                 :path ?path
-                :query-params (assoc ?query-params "pageNumber" (str (inc ?pageNumber)))}]}
+                :query-params (assoc ?query-params "pageNumber" (str (inc ?pageNumber)))
+                :headers {"accept" "application/json"}}]}
 
 
   {:match     [[:request, :method, "get"]
@@ -28,26 +32,31 @@
                [:response, :body, "items", ?i "courseId" ?id]]
    :generates [{:method "get"
                 :path   "/courses/{?id}"
-                :query-params {"returnTimelineOverrides" "true"}}
+                :query-params {"returnTimelineOverrides" "true"}
+                :headers {"accept" "application/json"}}
                {:method "get"
                 :path   "/courses/{?id}/offerings"
                 :query-params {"pageSize" "250"
-                               "consumer" "rio"}}]}
+                               "consumer" "rio"}
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "educationSpecificationId" ?id]]
    :generates [{:method "get"
                 :path   "/education-specifications/{?id}"
-                :query-params {"returnTimelineOverrides" "true"}}]}
+                :query-params {"returnTimelineOverrides" "true"}
+                :headers {"accept" "application/json"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "programId" ?id]]
    :generates [{:method "get"
                 :path   "/programs/{?id}"
-                :query-params {"returnTimelineOverrides" "true"}}
+                :query-params {"returnTimelineOverrides" "true"}
+                :headers {"accept" "application/json"}}
                {:method "get"
                 :path "/programs/{?id}/offerings"
                 :query-params {"pageSize" "250"
-                               "consumer" "rio"}}]}]}
+                               "consumer" "rio"}
+                :headers {"accept" "application/json"}}]}]}

--- a/profiles/rio-v6
+++ b/profiles/rio-v6
@@ -2,12 +2,10 @@
  :seeds
  [{:method "get"
    :path   "/courses"
-   :query-params {"consumer" "rio"}
-   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
+   :headers {"accept" "application/vnd.oeapi+json;version=6;consumer=rio;consumer-version=6"}}
   {:method "get"
    :path   "/programmes"
-   :query-params {"consumer" "rio"}
-   :headers {"accept" "application/vnd.oeapi+json;version=6"}}]
+   :headers {"accept" "application/vnd.oeapi+json;version=6;consumer=rio;consumer-version=6"}}]
 
  :rules
  [;; page through items list for any kind of entity
@@ -20,7 +18,7 @@
    :generates [{:method "get"
                 :path ?path
                 :query-params (assoc ?query-params "pageNumber" (str (inc ?pageNumber)))
-                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
+                :headers {"accept" "application/vnd.oeapi+json;version=6;consumer=rio;consumer-version=6"}}]}
 
 
   {:match     [[:request, :method, "get"]
@@ -28,21 +26,19 @@
                [:response, :body, "items", ?i "courseId" ?id]]
    :generates [{:method "get"
                 :path   "/courses/{?id}"
-                :query-params {"returnTimelineOverrides" "true"}}
+                :headers {"accept" "application/vnd.oeapi+json;version=6;consumer=rio;consumer-version=6"}}
                {:method "get"
                 :path   "/courses/{?id}/course-offerings"
-                :query-params {"pageSize" "250"
-                               "consumer" "rio"}
-                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
+                :query-params {"pageSize" "250"}
+                :headers {"accept" "application/vnd.oeapi+json;version=6;consumer=rio;consumer-version=6"}}]} 
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
                [:response, :body, "items", ?i "programmeId" ?id]]
    :generates [{:method "get"
                 :path   "/programmes/{?id}"
-                :query-params {"returnTimelineOverrides" "true"}}
+                :headers {"accept" "application/vnd.oeapi+json;version=6;consumer=rio;consumer-version=6"}}
                {:method "get"
                 :path "/programmes/{?id}/programme-offerings"
-                :query-params {"pageSize" "250"
-                               "consumer" "rio"}
-                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}]}
+                :query-params {"pageSize" "250"}
+                :headers {"accept" "application/vnd.oeapi+json;version=6;consumer=rio;consumer-version=6"}}]}]}

--- a/profiles/rio-v6
+++ b/profiles/rio-v6
@@ -2,10 +2,12 @@
  :seeds
  [{:method "get"
    :path   "/courses"
-   :query-params {"consumer" "rio"}} 
+   :query-params {"consumer" "rio"}
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}
   {:method "get"
    :path   "/programmes"
-   :query-params {"consumer" "rio"}}]
+   :query-params {"consumer" "rio"}
+   :headers {"accept" "application/vnd.oeapi+json;version=6"}}]
 
  :rules
  [;; page through items list for any kind of entity
@@ -17,7 +19,8 @@
                [:response, :body, "hasNextPage", true]]
    :generates [{:method "get"
                 :path ?path
-                :query-params (assoc ?query-params "pageNumber" (str (inc ?pageNumber)))}]}
+                :query-params (assoc ?query-params "pageNumber" (str (inc ?pageNumber)))
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
 
   {:match     [[:request, :method, "get"]
@@ -29,7 +32,8 @@
                {:method "get"
                 :path   "/courses/{?id}/course-offerings"
                 :query-params {"pageSize" "250"
-                               "consumer" "rio"}}]} 
+                               "consumer" "rio"}
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}
 
   {:match     [[:request, :method, "get"]
                [:response :status 200]
@@ -40,4 +44,5 @@
                {:method "get"
                 :path "/programmes/{?id}/programme-offerings"
                 :query-params {"pageSize" "250"
-                               "consumer" "rio"}}]}]}
+                               "consumer" "rio"}
+                :headers {"accept" "application/vnd.oeapi+json;version=6"}}]}]}

--- a/src/nl/surf/eduhub_validator/main.clj
+++ b/src/nl/surf/eduhub_validator/main.clj
@@ -20,9 +20,8 @@
    ;; insert default builtin-profile in options
    (fn [[short-opt :as option]]
      (if (= "-r" short-opt)
-       ["-r" "--profile PROFILE" "Path to profile or name of builtin profile"
-        :id :profile
-        :default (first included-profiles)]
+       ;; apie has no default for PROFILE option
+       (into option [:default (first included-profiles)])
        option))
    apie/cli-options))
 


### PR DESCRIPTION
Fixes typo in

  - "/organisations/{?id}/learning-component-offerings"
  - "/organisations/{?id}/test-component-offerings"

And also fixes course-offering items list in ooapi-v6 openapi spec. The latter fix should be pushed upstream in the ooapi repo.